### PR TITLE
Adding an auto-renaming script

### DIFF
--- a/.github/workflows/renaming.yml
+++ b/.github/workflows/renaming.yml
@@ -1,0 +1,35 @@
+name: Auto-Renaming
+on:
+  workflow_dispatch:
+    inputs:
+      username:
+        description: 'Your username'
+        required: true
+        type: string
+      modname:
+        description: 'Your mod name'
+        required: true
+        type: string
+
+jobs:
+  rename:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Run renaming script
+        run: ./renaming.sh "${{ github.event.inputs.modname }}" "${{ github.event.inputs.username }}"
+        
+      - name: Commit changes
+        run: |
+          git config --local user.name "${{ github.actor }}" 
+          git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+          git add .
+          git commit -m "Renaming with your datas"
+          
+      - name: Push changes  # push the output folder to your repo
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          force: true

--- a/renaming.sh
+++ b/renaming.sh
@@ -1,0 +1,25 @@
+# first argument is the mod's name and the second one is the mod author
+name=$1
+author=$2
+
+renaming()
+{
+        echo "Renaming in $(pwd)"
+        for f in WinchModTemplate*; do mv "$f" "$(echo "$f" | sed -e "s/WinchModTemplate/$name/g")"; done
+}
+
+change_occurences()
+{
+        for f in $@
+        do
+                echo "Changing occurrences in $f"
+                cat "$f" | sed -e "s/WinchModTemplate/$name/g" -e "s/YourName/$author/g"> "$f.tmp" && mv "$f.tmp" "$f"
+        done
+}
+
+cd WinchModTemplate
+change_occurences WinchModTemplate* mod_meta.json Loader.cs
+renaming
+cd ..
+change_occurences WinchModTemplate.sln
+renaming


### PR DESCRIPTION
This pull request adds a script and a github workflow to easily rename all the files with the name you want.
It's easier to rename, you won't have to rename every occurrences in the files.

This script is supposed to be used with the workflow and before cloning the repo on your machine